### PR TITLE
feat: New flag for passing extra args to run0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Options:
           run command (or edit file) as specified user name or ID
   -v, --validate
           validate a root login
+      --run0-extra-arg <RUN0_EXTRA_ARGS>
+          an extra argument to pass to run0 (can be specified multiple times)
   -h, --help
           Print help
   -V, --version

--- a/src/run0-sudo-shim/args.rs
+++ b/src/run0-sudo-shim/args.rs
@@ -101,6 +101,10 @@ pub struct Cli {
     #[clap(long, short = 'v', default_value_t = false)]
     pub validate: bool,
 
+    /// an extra argument to pass to run0 (can be specified multiple times)
+    #[clap(long = "run0-extra-arg", allow_hyphen_values = true)]
+    pub run0_extra_args: Vec<String>,
+
     /// command to be executed
     #[arg(last(false), allow_hyphen_values = true)]
     pub command: Vec<String>,

--- a/src/run0-sudo-shim/main.rs
+++ b/src/run0-sudo-shim/main.rs
@@ -67,6 +67,8 @@ fn main() {
         .file_descriptor_limit
         .map(|limit_nofile| format!("--property=LimitNOFILE={limit_nofile}"));
 
+    let run0_extra_args = cli.run0_extra_args;
+
     if command.is_empty() && !cli.login {
         let mut cmd = clap::Command::new(env!("CARGO_PKG_NAME"));
         cmd.print_help().ok();
@@ -84,6 +86,7 @@ fn main() {
         .args(user.iter())
         .args(nofile.iter())
         .args(env_flags)
+        .args(run0_extra_args.iter())
         .args(command)
         .exec();
 


### PR DESCRIPTION
I wanted to adjust the `--background` of run0 because the default doesn't work well with my terminal theme. I thought it could be more flexible and opted to create a catch-all approach that allows passing any extra arguments to run0.

I initially tried it as a single string but passing it multiple times is clearer and simpler.

Example wrapper from my NixOS configs:

```nix
package = pkgs.symlinkJoin {
  name = "sudo";
  paths = [ inputs.run0-sudo-shim.packages.${pkgs.stdenv.hostPlatform.system}.run0-sudo-shim ];
  nativeBuildInputs = [ pkgs.makeWrapper ];
  postBuild = ''
    wrapProgram $out/bin/sudo --add-flags "--run0-extra-arg=--background="
  '';
};
```