### PR TITLE
nix: use polkit-stdin-agent from nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
@@ -40,62 +22,25 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779847850,
-        "narHash": "sha256-4xcMyKu9RgxxgIRnEzW79jiSvqzs0shQJxI2G3Mbu18=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c6db2b5d257d845bbee67a38dee43bbca3bd462",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable-small",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
-      }
-    },
-    "polkit-stdin-agent": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779895539,
-        "narHash": "sha256-Nl/+IBbUEsxSKSWLXwUB3mV4iAG0z9mv+Bl6CSeFzR4=",
-        "ref": "refs/heads/main",
-        "rev": "95beb16b78de357ac11de2b492597c1add2503b7",
-        "revCount": 16,
-        "type": "git",
-        "url": "https://git.grimmauld.de/mirrors/polkit-stdin-agent"
-      },
-      "original": {
-        "type": "git",
-        "url": "https://git.grimmauld.de/mirrors/polkit-stdin-agent"
       }
     },
     "root": {
       "inputs": {
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": "nixpkgs",
-        "polkit-stdin-agent": "polkit-stdin-agent",
         "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     },
     "treefmt-nix": {
@@ -105,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,7 @@
   description = "a shim imitating sudo, but using run0 in the background";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
-    polkit-stdin-agent = {
-      # url = "git+https://codeberg.org/r-vdp/polkit-stdin-agent"; # original
-      url = "git+https://git.grimmauld.de/mirrors/polkit-stdin-agent"; # original is on codeberg, but gets rate-limited causing GHA to fail.
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nix-github-actions = {
       url = "github:nix-community/nix-github-actions";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -24,7 +19,6 @@
       nixpkgs,
       nix-github-actions,
       treefmt-nix,
-      polkit-stdin-agent,
       ...
     }:
     let
@@ -44,9 +38,7 @@
             })
             [
               "x86_64-linux"
-              "x86_64-darwin"
               "aarch64-linux"
-              "aarch64-darwin"
             ]
         );
 
@@ -91,12 +83,7 @@
       packages = forEachSystem (
         { pkgs, system }:
         {
-          # use polkit-stdin-agent from nixpkgs once available
-          # https://github.com/NixOS/nixpkgs/pull/512018
-          ${name} = pkgs.callPackage package {
-            polkit-stdin-agent =
-              pkgs.polkit-stdin-agent or polkit-stdin-agent.packages."${system}".polkit-stdin-agent;
-          };
+          ${name} = pkgs.callPackage package { };
           default = self.packages.${system}.${name};
         }
       );
@@ -110,7 +97,7 @@
               pkgs.clippy
               pkgs.rust-analyzer
               pkgs.rustfmt
-              polkit-stdin-agent.packages."${system}".polkit-stdin-agent
+              pkgs.polkit-stdin-agent
             ];
           };
         }
@@ -133,7 +120,7 @@
               };
 
               # environment.systemPackages = [
-              #   polkit-stdin-agent.packages."${system}".polkit-stdin-agent
+              #   pkgs.polkit-stdin-agent
               # ];
 
               users.users = {
@@ -163,13 +150,7 @@
       };
 
       overlays.default = final: prev: {
-        ${name} = final.callPackage package {
-          # use polkit-stdin-agent from nixpkgs once available
-          # https://github.com/NixOS/nixpkgs/pull/512018
-          polkit-stdin-agent =
-            prev.polkit-stdin-agent
-              or polkit-stdin-agent.packages."${prev.stdenv.hostPlatform.system}".polkit-stdin-agent;
-        };
+        ${name} = final.callPackage package { };
       };
 
       nixosModules.default =


### PR DESCRIPTION
https://status.nixos.org/
https://github.com/NixOS/nixpkgs/pull/526235
https://github.com/NixOS/nixpkgs/pull/512018

Both of these have reached their respective channels, polkit-stdin-agent from flake is no longer necessary.