### PR TITLE
bugfix: don't use partition_point

### DIFF
--- a/src/run0-sudo-shim/builder.rs
+++ b/src/run0-sudo-shim/builder.rs
@@ -207,9 +207,14 @@ pub fn parse_to_run0_cli(
         buf.push(format!("--group={}", group.trim_start_matches('#')))
     }
 
-    let env_var_prefix_split_idx = cli
-        .command
-        .partition_point(|arg| arg.contains("=") && !arg.starts_with("=") && !arg.starts_with("/"));
+    let mut env_var_prefix_split_idx: usize = 0;
+    for arg in cli.command.iter() {
+        if arg.contains("=") && !arg.starts_with("=") && !arg.starts_with("/") {
+            env_var_prefix_split_idx += 1;
+        } else {
+            break;
+        }
+    }
 
     let (extra_env_vars, command) = cli.command.split_at(env_var_prefix_split_idx);
 
@@ -416,6 +421,24 @@ mod tests {
                 String::from("--setenv=bar=buzz"),
                 String::from("--"),
                 String::from("prog")
+            ])
+        );
+    }
+
+    #[test]
+    fn test_set_env_prefix_after_command() {
+        // regression test for https://github.com/LordGrimmauld/run0-sudo-shim/issues/20
+        let cli = Cli::parse_from(["sudo", "env", "-i", "foo=42", "ls"]);
+        let build_result = parse_to_run0_cli(cli, None, 1000, vec![]);
+        assert_eq!(
+            build_result,
+            Ok(vec![
+                String::from(RUN0_CMD),
+                String::from("--"),
+                String::from("env"),
+                String::from("-i"),
+                String::from("foo=42"),
+                String::from("ls"),
             ])
         );
     }


### PR DESCRIPTION
According to the rust docs:

> Returns the index of the partition point according to the given predicate (the index of the first element of the second partition).
>
> The slice is assumed to be partitioned according to the given predicate. This means that all elements for which the predicate returns true are at the start of the slice and all elements for which the predicate returns false are at the end. For example, [7, 15, 3, 5, 4, 12, 6] is partitioned under the predicate x % 2 != 0 (all odd numbers are at the start, all even at the end).
>
> If this slice is not partitioned, the returned result is unspecified and meaningless, as this method performs a kind of binary search.

I wanted to be clever, and that backfired. Instead just use a boring for loop to find the index to split at.

Closes #20